### PR TITLE
[PKG-4417] 0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!/abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr2/79c2649

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - poetry-core >=1.0.0
     - pip
   run:
-    - python >=3.8.1
+    - python
     - langchain-core >=0.1.28,<0.2.0
   run_constrained:
     - lxml >=5.1.0,<6.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: ac459fa98799f5117ad5425a9330b21961321e30bc19a2a2f9f761ddadd62aa1
 
 build:
-  noarch: python
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.8,<4.0
+    - python
     - poetry-core >=1.0.0
     - pip
   run:
-    - python >=3.8.1,<4.0
+    - python >=3.8.1
     - langchain-core >=0.1.28,<0.2.0
   run_constrained:
     - lxml >=5.1.0,<6.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/langchain_text_splitters-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
   sha256: ac459fa98799f5117ad5425a9330b21961321e30bc19a2a2f9f761ddadd62aa1
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,14 @@ test:
 about:
   home: https://github.com/langchain-ai/langchain
   dev_url: https://github.com/langchain-ai/langchain/tree/master/libs/text-splitters
+  doc_url: https://python.langchain.com/v0.1/docs/modules/data_connection/document_transformers/
   summary: LangChain text splitting utilities
+  description: |
+    LangChain Text Splitters contains utilities for splitting
+    into chunks a wide variety of text documents.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
langchain-text-splitters 0.0.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4417]
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/master/libs/text-splitters)
- ~Upstream changelog/diff~ Initial release, no release notes or tagged release commit on upstream.
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/langchain-core-feedstock/pull/2
  - https://github.com/AnacondaRecipes/langsmith-feedstock/pull/3

### Explanation of changes:

- Omitted tests since they're not included in Pypi source, and there's no matching release on Github.
- Dropped noarch.
- Using staging channel for `langchain-core` until that is merged and uploaded.

[PKG-4417]: https://anaconda.atlassian.net/browse/PKG-4417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ