### PR TITLE
Upgraded to version 0.3.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr2/79c2649

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-text-splitters" %}
-{% set version = "0.0.1" %}
+{% set version = "0.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: ac459fa98799f5117ad5425a9330b21961321e30bc19a2a2f9f761ddadd62aa1
+  sha256: 81e6515d9901d6dd8e35fb31ccd4f30f76d44b771890c789dc835ef9f16204df
 
 build:
-  skip: true  # [py<38]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
@@ -21,9 +21,7 @@ requirements:
     - pip
   run:
     - python
-    - langchain-core >=0.1.28,<0.2.0
-  run_constrained:
-    - lxml >=5.1.0,<6.0.0
+    - langchain-core >=0.3.15,<0.4.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 81e6515d9901d6dd8e35fb31ccd4f30f76d44b771890c789dc835ef9f16204df
 
 build:
-  skip: true  # [py<39]
+  skip: true  # [py<39 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 


### PR DESCRIPTION
langchain-text-splitters 0.3.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6283](https://anaconda.atlassian.net/browse/PKG-6283) 
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/langchain-text-splitters==0.3.2)

### Explanation of changes:

- Updating to version 0.3.2


[PKG-6283]: https://anaconda.atlassian.net/browse/PKG-6283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ