### PR TITLE
langchaing-text-splitters 0.3.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-upload_channels:
-  - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr6/e6e69e0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-text-splitters" %}
-{% set version = "0.3.2" %}
+{% set version = "0.3.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: 81e6515d9901d6dd8e35fb31ccd4f30f76d44b771890c789dc835ef9f16204df
+  sha256: c596958dcab15fdfe0627fd36ce9d588d0a7e35593af70cd10d0a4a06d69b3ee
 
 build:
   skip: true  # [py<39 or s390x]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6023](https://anaconda.atlassian.net/browse/PKG-6023)
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/master/libs/text-splitters)

### Explanation of changes:

- Update version
- Remove Snowflake channel


[PKG-6023]: https://anaconda.atlassian.net/browse/PKG-6023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ