### PR TITLE
langchain-text-splitters 0.3.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr7/41b1218

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr7/41b1218

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 116d4b9f2a22dda357d0b79e30acf005c5518177971c66a9f1ab0edfdb0f912e
 
 build:
-  skip: true  # [py<39 or s390x]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-text-splitters" %}
-{% set version = "0.3.3" %}
+{% set version = "0.3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: c596958dcab15fdfe0627fd36ce9d588d0a7e35593af70cd10d0a4a06d69b3ee
+  sha256: 116d4b9f2a22dda357d0b79e30acf005c5518177971c66a9f1ab0edfdb0f912e
 
 build:
   skip: true  # [py<39 or s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,12 @@ build:
 requirements:
   host:
     - python
-    - poetry-core >=1.0.0
+    - pdm-backend
     - pip
   run:
     - python
-    - langchain-core >=0.3.15,<0.4.0
+    - langchain-core
+    - jupyter <2.0.0,>=1.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,7 @@ requirements:
     - pip
   run:
     - python
-    - langchain-core
-    - jupyter <2.0.0,>=1.0.0
+    - langchain-core <1.0.0,>=0.3.51
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8165](https://anaconda.atlassian.net/browse/PKG-8165) 
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/master/libs/text-splitters)
- Relevant dependency PRs:
  - `langchain-text-splitters` ➡️ `langchain`

### Explanation of changes:

- Update version
- Remove s390x info
- Update dependencies


[PKG-8165]: https://anaconda.atlassian.net/browse/PKG-8165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ