### PR TITLE
langchain-text-splitters 0.3.11 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-text-splitters" %}
-{% set version = "0.3.8" %}
+{% set version = "0.3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: 116d4b9f2a22dda357d0b79e30acf005c5518177971c66a9f1ab0edfdb0f912e
+  sha256: 7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc
+  patches:
+    - patches/0001-update-conftest.patch
 
 build:
   skip: true  # [py<39]
@@ -21,15 +23,40 @@ requirements:
     - pip
   run:
     - python
-    - langchain-core <1.0.0,>=0.3.51
+    - langchain-core <2.0.0,>=0.3.75
+  run_constrained:
+    - mypy <1.18,>=1.17.1
+    - lxml-stubs <1.0.0,>=0.5.1
+    - types-requests <3.0.0.0,>=2.31.0.20240218
+    - tiktoken <1.0.0,>=0.8.0
 
 test:
+  source_files:
+    - tests
   imports:
     - langchain_text_splitters
+    - langchain_text_splitters.base
+    - langchain_text_splitters.character
+    - langchain_text_splitters.html
+    - langchain_text_splitters.json
+    - langchain_text_splitters.jsx
+    - langchain_text_splitters.konlpy
+    - langchain_text_splitters.latex
+    - langchain_text_splitters.markdown
+    - langchain_text_splitters.nltk
+    - langchain_text_splitters.python
+    - langchain_text_splitters.sentence_transformers
+    - langchain_text_splitters.spacy
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests
   requires:
     - pip
+    - pytest
+    - lxml
+    - bs4
+    - nltk
 
 about:
   home: https://github.com/langchain-ai/langchain

--- a/recipe/patches/0001-update-conftest.patch
+++ b/recipe/patches/0001-update-conftest.patch
@@ -1,0 +1,27 @@
+From bf5e6bad4d952a933954673626d3b8d218009c73 Mon Sep 17 00:00:00 2001
+From: Patryk Kups <pkups@anaconda.com>
+Date: Mon, 6 Oct 2025 10:14:03 +0200
+Subject: [PATCH] path
+
+---
+ tests/unit_tests/conftest.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/unit_tests/conftest.py b/tests/unit_tests/conftest.py
+index ad5ea62..bef5d7c 100644
+--- a/tests/unit_tests/conftest.py
++++ b/tests/unit_tests/conftest.py
+@@ -42,8 +42,8 @@ def pytest_collection_modifyitems(config: Config, items: Sequence[Function]) ->
+     # Used to avoid repeated calls to `util.find_spec`
+     required_pkgs_info: dict[str, bool] = {}
+ 
+-    only_extended = config.getoption("--only-extended") or False
+-    only_core = config.getoption("--only-core") or False
++    only_extended = True
++    only_core = False
+ 
+     if only_extended and only_core:
+         msg = "Cannot specify both `--only-extended` and `--only-core`."
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
langchain-text-splitters 0.3.11 

**Destination channel:** Defaults

### Links

- [PKG-10009]
- dev_url:        https://github.com/langchain-ai/langchain/tree/langchain-text-splitters==0.3.11
- conda_forge:    https://github.com/conda-forge/langchain-text-splitters-feedstock
- pypi:           https://pypi.org/project/langchain-text-splitters/0.3.11
- pypi inspector: https://inspector.pypi.io/project/langchain-text-splitters/0.3.11

### Explanation of changes:

- new version number


[PKG-10009]: https://anaconda.atlassian.net/browse/PKG-10009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ