### PR TITLE
langchain-text-splitter 1.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/langsmith-feedstock/pr10/1fbd706
-  - https://staging.continuum.io/pbp/fs/langchain-core-feedstock/pr9/0b9d4b9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/langsmith-feedstock/pr10/1fbd706
+  - https://staging.continuum.io/pbp/fs/langchain-core-feedstock/pr9/0b9d4b9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,13 +36,9 @@ test:
   requires:
     - pip
     - pytest >=8.0.0,<9.0.0
-    - pytest-mock >=3.10.0,<4.0.0
-    - pytest-socket >=0.7.0,<1.0.0
-    - pytest-xdist >=3.6.1,<4.0.0
     - freezegun>=1.2.2,<2.0.0
     - nltk >=3.9.1,<4.0.0
     - spacy >=3.8.7,<4.0.0  # [py<314]
-    - thinc >=8.3.6,<9.0.0  # [py<314]
     # transformers is not available for python 3.14
     - transformers >=4.51.3,<5.0.0  # [py<314]
     - sentence-transformers >=3.0.1,<4.0.0  # [py<314]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,10 +38,11 @@ test:
     - pytest >=8.0.0,<9.0.0
     - freezegun>=1.2.2,<2.0.0
     - nltk >=3.9.1,<4.0.0
-    - spacy >=3.8.7,<4.0.0  # [py<314]
-    # transformers is not available for python 3.14
-    - transformers >=4.51.3,<5.0.0  # [py<314]
-    - sentence-transformers >=3.0.1,<4.0.0  # [py<314]
+    # Integration tests have dependency conflicts.
+    # - spacy >=3.8.7,<4.0.0  # [py<314]
+    ## transformers is not available for python 3.14
+    # - transformers >=4.51.3,<5.0.0  # [py<314]
+    # - sentence-transformers >=3.0.1,<4.0.0  # [py<314]
     # - tiktoken >=0.8.0,<1.0.0  # [py<314]
     # - scipy >=1.7.0,<2.0.0  # [py<313]
     # - scipy >=1.14.1,<2.0.0  # [py>=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
   sha256: 7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc
   patches:
     - patches/0001-update-conftest.patch
@@ -14,7 +14,7 @@ source:
 build:
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,15 +36,29 @@ test:
   requires:
     - pip
     - pytest >=8.0.0,<9.0.0
+    - pytest-mock >=3.10.0,<4.0.0
+    - pytest-socket >=0.7.0,<1.0.0
+    - pytest-xdist >=3.6.1,<4.0.0
     - freezegun>=1.2.2,<2.0.0
     - nltk >=3.9.1,<4.0.0
+    - spacy >=3.8.7,<4.0.0  # [py<314]
+    - thinc >=8.3.6,<9.0.0  # [py<314]
+    # transformers is not available for python 3.14
+    - transformers >=4.51.3,<5.0.0  # [py<314]
+    - sentence-transformers>=3.0.1,<4.0.0  # [py<314]
+    - tiktoken >=0.8.0,<1.0.0  # [py<314]
+    - scipy >=1.7.0,<2.0.0  # [py<313]
+    - scipy >=1.14.1,<2.0.0  # [py>=313]
+    # 'en-core-web-sm' from spacy-models is required for the tests.
+    # - spacy-models
     # lxml and bs4 are not mentioned in the dependencies, but it is required for the tests
     - bs4
     - lxml
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests
+    - pytest -v tests  # [py<314]
+    - pytest -v tests --ignore=tests/integration_tests/test_text_splitter.py  # [py==314]
 
 about:
   home: https://github.com/langchain-ai/langchain

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
     - thinc >=8.3.6,<9.0.0  # [py<314]
     # transformers is not available for python 3.14
     - transformers >=4.51.3,<5.0.0  # [py<314]
-    # - sentence-transformers>=3.0.1,<4.0.0  # [py<314]
+    - sentence-transformers >=3.0.1,<4.0.0  # [py<314]
     # - tiktoken >=0.8.0,<1.0.0  # [py<314]
     # - scipy >=1.7.0,<2.0.0  # [py<313]
     # - scipy >=1.14.1,<2.0.0  # [py>=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests  # [py<314]
+    - pytest -v tests/unit_tests/  # [py<314]
     - pytest -v tests --ignore=tests/integration_tests/test_text_splitter.py  # [py==314]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,11 @@ requirements:
     - python
     - langchain-core >=1.2.0,<2.0.0
   run_constrained:
-    - lxml >=4.9.3,<6.0.0
-    - beautifulsoup4 >=4.12.3,<5.0.0
+    # Extended dependencies,
+    # see https://github.com/langchain-ai/langchain/blob/master/libs/text-splitters/extended_testing_deps.txt,
+    # and https://github.com/langchain-ai/langchain/blob/langchain-text-splitters%3D%3D1.1.0/libs/text-splitters/pyproject.toml#L37
+    - lxml >=4.9.3,<7.0.0
+    - beautifulsoup4 >=4.13.5,<5.0.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,8 @@ test:
     - pytest >=8.0.0,<9.0.0
     - freezegun>=1.2.2,<2.0.0
     - nltk >=3.9.1,<4.0.0
-    # lxml is not mentioned in the dependencies, but it is required for the tests
+    # lxml and bs4 are not mentioned in the dependencies, but it is required for the tests
+    - bs4
     - lxml
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-text-splitters" %}
-{% set version = "0.3.11" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,61 +7,46 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: 7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc
+  sha256: 75e58acb7585dc9508f3cd9d9809cb14751283226c2d6e21fb3a9ae57582ca22
   patches:
     - patches/0001-update-conftest.patch
 
 build:
-  skip: true  # [py<39]
+  number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
 
 requirements:
   host:
     - python
-    - pdm-backend
+    - hatchling
     - pip
   run:
     - python
-    - langchain-core <2.0.0,>=0.3.75
+    - langchain-core >=1.2.0,<2.0.0
   run_constrained:
-    - mypy <1.18,>=1.17.1
-    - lxml-stubs <1.0.0,>=0.5.1
-    - types-requests <3.0.0.0,>=2.31.0.20240218
-    - tiktoken <1.0.0,>=0.8.0
+    - lxml >=4.9.3,<6.0.0
+    - beautifulsoup4 >=4.12.3,<5.0.0
 
 test:
   source_files:
     - tests
   imports:
     - langchain_text_splitters
-    - langchain_text_splitters.base
-    - langchain_text_splitters.character
-    - langchain_text_splitters.html
-    - langchain_text_splitters.json
-    - langchain_text_splitters.jsx
-    - langchain_text_splitters.konlpy
-    - langchain_text_splitters.latex
-    - langchain_text_splitters.markdown
-    - langchain_text_splitters.nltk
-    - langchain_text_splitters.python
-    - langchain_text_splitters.sentence_transformers
-    - langchain_text_splitters.spacy
+  requires:
+    - pip
+    - pytest >=8.0.0,<9.0.0
+    - freezegun>=1.2.2,<2.0.0
+    - nltk >=3.9.1,<4.0.0
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -v tests
-  requires:
-    - pip
-    - pytest
-    - lxml
-    - bs4
-    - nltk
 
 about:
   home: https://github.com/langchain-ai/langchain
   dev_url: https://github.com/langchain-ai/langchain/tree/master/libs/text-splitters
-  doc_url: https://python.langchain.com/v0.1/docs/modules/data_connection/document_transformers/
+  doc_url: https://reference.langchain.com/python/langchain_text_splitters/
   summary: LangChain text splitting utilities
   description: |
     LangChain Text Splitters contains utilities for splitting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,10 +45,10 @@ test:
     - thinc >=8.3.6,<9.0.0  # [py<314]
     # transformers is not available for python 3.14
     - transformers >=4.51.3,<5.0.0  # [py<314]
-    - sentence-transformers>=3.0.1,<4.0.0  # [py<314]
-    - tiktoken >=0.8.0,<1.0.0  # [py<314]
-    - scipy >=1.7.0,<2.0.0  # [py<313]
-    - scipy >=1.14.1,<2.0.0  # [py>=313]
+    # - sentence-transformers>=3.0.1,<4.0.0  # [py<314]
+    # - tiktoken >=0.8.0,<1.0.0  # [py<314]
+    # - scipy >=1.7.0,<2.0.0  # [py<313]
+    # - scipy >=1.14.1,<2.0.0  # [py>=313]
     # 'en-core-web-sm' from spacy-models is required for the tests.
     # - spacy-models
     # lxml and bs4 are not mentioned in the dependencies, but it is required for the tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,8 @@ test:
     - pytest >=8.0.0,<9.0.0
     - freezegun>=1.2.2,<2.0.0
     - nltk >=3.9.1,<4.0.0
+    # lxml is not mentioned in the dependencies, but it is required for the tests
+    - lxml
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10949) 
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/langchain-text-splitters%3D%3D1.1.0/libs/text-splitters)

### Explanation of changes:

- Skip py<310
- Update dependencies
- Remove imports that are not python packages
- Run only unit test for py<314 because integration test dependencies caused conflicts.
- Update doc_url

### Notes:

-